### PR TITLE
go: fix polarityReasoning and reasoning when generating Compat responses

### DIFF
--- a/go/causal/structured_output.go
+++ b/go/causal/structured_output.go
@@ -181,7 +181,7 @@ func (r *Relationship) Key() string {
 type RelationshipEntry struct {
 	Variable          string `json:"variable"`
 	Polarity          string `json:"polarity"` // "+", or "-"
-	PolarityReasoning string `json:"polarityReasoning"`
+	PolarityReasoning string `json:"polarity_reasoning"`
 }
 
 type Chain struct {
@@ -223,6 +223,8 @@ func (m *Map) Compat() SdJson {
 				To:                to,
 				Polarity:          r.Polarity,
 				PolarityReasoning: r.PolarityReasoning,
+				// use the overall reasoning for the chain for this relationship
+				Reasoning: chain.Reasoning,
 			}
 			rk := relationship.Key()
 			if seenRelationships.Contains(rk) {

--- a/go/causal/testdata/compat_out1.json
+++ b/go/causal/testdata/compat_out1.json
@@ -3,7 +3,9 @@
     {
       "from": "frimbulators",
       "to": "whatajigs",
-      "polarity": "+"
+      "polarity": "+",
+      "reasoning": "A decrease in frimbulators leads to a decrease in whatajigs—this is a direct causal relationship.",
+      "polarityReasoning": "Fewer frimbulators causes fewer whatajigs, and more frimbulators causes more whatajigs, indicating a positive relationship."
     }
   ],
   "variables": [


### PR DESCRIPTION
A pair of fixes - one fixes unmarshalling the LLM's response, the other uses the reasoning for the causal chain as the reasoning for each relationship (best we can do for now given the mismatch between asking the LLM to talk about causal chains, and the engine API wanting relationships)

cc @wasbridge 