### PR TITLE
go: better sdjson support

### DIFF
--- a/engines/causal-chains/engine.js
+++ b/engines/causal-chains/engine.js
@@ -99,14 +99,7 @@ class Engine {
             fs.writeFileSync(inputPath, JSON.stringify(input));
             const result = execSync(`${__dirname}/causal-chains ${inputPath}`, {cwd: tempDir});
 
-            let response = JSON.parse(result.toString());
-            response.model.variables = response.model.variables.map((v) => {
-                return {
-                    type: "variable",
-                    name: v
-                };
-            });
-            return response;
+            return JSON.parse(result.toString());
         } catch (err) {
             console.log(`causal-chains returned non-zero exit code: ${err.status}`);
             return {

--- a/engines/causal-chains/main.go
+++ b/engines/causal-chains/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/UB-IAD/sd-ai/go/causal"
 	"github.com/UB-IAD/sd-ai/go/chat"
 	"github.com/UB-IAD/sd-ai/go/llm/openai"
+	"github.com/UB-IAD/sd-ai/go/sdjson"
 )
 
 type parameters struct {
@@ -34,7 +35,7 @@ type supportingInfo struct {
 
 type output struct {
 	SupportingInfo supportingInfo `json:"supportingInfo"`
-	Model          causal.SdJson  `json:"model"`
+	Model          sdjson.Model   `json:"model"`
 }
 
 // isOpenAIModel returns true if the given model is an OpenAI model.

--- a/go/causal/output_test.go
+++ b/go/causal/output_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/UB-IAD/sd-ai/go/sdjson"
 )
 
 func TestCanonicalize(t *testing.T) {
@@ -107,7 +109,7 @@ func TestCompatTransformation(t *testing.T) {
 	require.NoError(t, err)
 
 	actual := in.Compat()
-	var expected SdJson
+	var expected sdjson.Model
 	err = json.Unmarshal([]byte(compatOut1), &expected)
 	require.NoError(t, err)
 

--- a/go/causal/testdata/compat_out1.json
+++ b/go/causal/testdata/compat_out1.json
@@ -9,7 +9,13 @@
     }
   ],
   "variables": [
-    "frimbulators",
-    "whatajigs"
+    {
+      "name": "frimbulators",
+      "type": "variable"
+    },
+    {
+      "name": "whatajigs",
+      "type": "variable"
+    }
   ]
 }

--- a/go/sdjson/sdjson.go
+++ b/go/sdjson/sdjson.go
@@ -1,0 +1,147 @@
+package sdjson
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type Polarity int
+
+const (
+	NegativePolarity Polarity = iota
+	PositivePolarity
+)
+
+func (p Polarity) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + p.Symbol() + "\""), nil
+}
+
+func (p *Polarity) UnmarshalJSON(b []byte) error {
+	switch string(b) {
+	case `"+"`:
+		*p = PositivePolarity
+	case `"-"`:
+		*p = NegativePolarity
+	default:
+		return fmt.Errorf("unknown polarity: %q", string(b))
+	}
+	return nil
+}
+
+var (
+	_ json.Unmarshaler = (*Polarity)(nil)
+	_ json.Marshaler   = Polarity(0)
+)
+
+func (p Polarity) IsPositive() bool {
+	return p == PositivePolarity
+}
+
+func (p Polarity) IsNegative() bool {
+	return !p.IsPositive()
+}
+
+func (p Polarity) Symbol() string {
+	switch p {
+	case PositivePolarity:
+		return "+"
+	default:
+		return "-"
+	}
+}
+
+func (p Polarity) String() string {
+	return p.Symbol()
+}
+
+type VariableType int
+
+const (
+	VariableTypeAux VariableType = iota
+	VariableTypeStock
+	VariableTypeFlow
+)
+
+func (v VariableType) String() string {
+	switch v {
+	case VariableTypeAux:
+		return "variable"
+	case VariableTypeStock:
+		return "stock"
+	case VariableTypeFlow:
+		return "flow"
+	default:
+		return ""
+	}
+}
+
+func (v VariableType) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + v.String() + "\""), nil
+}
+
+func (p *VariableType) UnmarshalJSON(b []byte) error {
+	switch string(b) {
+	case `"variable"`:
+		*p = VariableTypeAux
+	case `"stock"`:
+		*p = VariableTypeStock
+	case `"flow"`:
+		*p = VariableTypeFlow
+	default:
+		return fmt.Errorf("unknown variable type: %q", string(b))
+	}
+	return nil
+}
+
+var (
+	_ json.Unmarshaler = (*VariableType)(nil)
+	_ json.Marshaler   = VariableType(0)
+)
+
+type Point struct {
+	X float64 `json:"x"`
+	Y float64 `json:"y"`
+}
+
+type GraphicalFunction struct {
+	Points []Point `json:"points"`
+}
+
+type Variable struct {
+	Name              string             `json:"name"`
+	Type              VariableType       `json:"type"`
+	Equation          string             `json:"equation,omitzero"`
+	Documentation     string             `json:"documentation,omitzero"`
+	Units             string             `json:"units,omitzero"`
+	Inflows           []string           `json:"inflows,omitzero"`
+	Outflows          []string           `json:"outflows,omitzero"`
+	GraphicalFunction *GraphicalFunction `json:"graphicalFunction,omitzero"`
+}
+
+type Relationship struct {
+	From              string `json:"from"`
+	To                string `json:"to"`
+	Polarity          string `json:"polarity"` // "+", or "-"
+	Reasoning         string `json:"reasoning,omitzero"`
+	PolarityReasoning string `json:"polarityReasoning,omitzero"`
+}
+
+func (r *Relationship) Key() string {
+	// ignore polarity: we don't want duplicate relationships with opposite polarity
+	return fmt.Sprintf("%q->%q", r.From, r.To)
+}
+
+type Specs struct {
+	StartTime float64 `json:"startTime"`
+	StopTime  float64 `json:"stopTime"`
+	DT        float64 `json:"dt,omitzero"`
+	SaveStep  float64 `json:"saveStep,omitzero"`
+	TimeUnits string  `json:"timeUnits,omitzero"`
+}
+
+// Model is the format that sd-ai expects to talk about models.
+type Model struct {
+	Variables     []Variable     `json:"variables,omitzero"`
+	Relationships []Relationship `json:"relationships,omitzero"`
+	Specs         Specs          `json:"specs,omitzero"`
+}

--- a/go/sdjson/sdjson_test.go
+++ b/go/sdjson/sdjson_test.go
@@ -1,0 +1,576 @@
+package sdjson
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPolarityRoundtrip(t *testing.T) {
+	tests := []struct {
+		name     string
+		polarity Polarity
+		expected string
+	}{
+		{
+			name:     "positive polarity",
+			polarity: PositivePolarity,
+			expected: `"+"`,
+		},
+		{
+			name:     "negative polarity",
+			polarity: NegativePolarity,
+			expected: `"-"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test Marshal
+			data, err := json.Marshal(tt.polarity)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(data))
+
+			// Test Unmarshal
+			var p Polarity
+			err = json.Unmarshal(data, &p)
+			require.NoError(t, err)
+			assert.Equal(t, tt.polarity, p)
+		})
+	}
+}
+
+func TestPolarityUnmarshalError(t *testing.T) {
+	invalidInputs := []string{
+		`"?"`,
+		`"positive"`,
+		`""`,
+		`null`,
+		`123`,
+	}
+
+	for _, input := range invalidInputs {
+		t.Run(input, func(t *testing.T) {
+			var p Polarity
+			err := json.Unmarshal([]byte(input), &p)
+			assert.Error(t, err, "Expected error for input %s", input)
+		})
+	}
+}
+
+func TestPolarityMethods(t *testing.T) {
+	tests := []struct {
+		polarity   Polarity
+		isPositive bool
+		isNegative bool
+		symbol     string
+		str        string
+	}{
+		{
+			polarity:   PositivePolarity,
+			isPositive: true,
+			isNegative: false,
+			symbol:     "+",
+			str:        "+",
+		},
+		{
+			polarity:   NegativePolarity,
+			isPositive: false,
+			isNegative: true,
+			symbol:     "-",
+			str:        "-",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.str, func(t *testing.T) {
+			assert.Equal(t, tt.isPositive, tt.polarity.IsPositive())
+			assert.Equal(t, tt.isNegative, tt.polarity.IsNegative())
+			assert.Equal(t, tt.symbol, tt.polarity.Symbol())
+			assert.Equal(t, tt.str, tt.polarity.String())
+		})
+	}
+}
+
+func TestVariableTypeRoundtrip(t *testing.T) {
+	tests := []struct {
+		name     string
+		varType  VariableType
+		expected string
+	}{
+		{
+			name:     "aux/variable type",
+			varType:  VariableTypeAux,
+			expected: `"variable"`,
+		},
+		{
+			name:     "stock type",
+			varType:  VariableTypeStock,
+			expected: `"stock"`,
+		},
+		{
+			name:     "flow type",
+			varType:  VariableTypeFlow,
+			expected: `"flow"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test Marshal
+			data, err := json.Marshal(tt.varType)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(data))
+
+			// Test Unmarshal
+			var vt VariableType
+			err = json.Unmarshal(data, &vt)
+			require.NoError(t, err)
+			assert.Equal(t, tt.varType, vt)
+		})
+	}
+}
+
+func TestVariableTypeUnmarshalError(t *testing.T) {
+	invalidInputs := []string{
+		`"unknown"`,
+		`"aux"`,
+		`""`,
+		`null`,
+		`123`,
+	}
+
+	for _, input := range invalidInputs {
+		t.Run(input, func(t *testing.T) {
+			var vt VariableType
+			err := json.Unmarshal([]byte(input), &vt)
+			assert.Error(t, err, "Expected error for input %s", input)
+		})
+	}
+}
+
+func TestVariableTypeString(t *testing.T) {
+	tests := []struct {
+		varType  VariableType
+		expected string
+	}{
+		{VariableTypeAux, "variable"},
+		{VariableTypeStock, "stock"},
+		{VariableTypeFlow, "flow"},
+		{VariableType(999), ""}, // unknown type
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.varType.String())
+		})
+	}
+}
+
+func TestPointRoundtrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		point Point
+	}{
+		{
+			name:  "zero point",
+			point: Point{X: 0, Y: 0},
+		},
+		{
+			name:  "positive point",
+			point: Point{X: 10.5, Y: 20.3},
+		},
+		{
+			name:  "negative point",
+			point: Point{X: -10.5, Y: -20.3},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.point)
+			require.NoError(t, err)
+
+			var p Point
+			err = json.Unmarshal(data, &p)
+			require.NoError(t, err)
+			assert.Equal(t, tt.point, p)
+		})
+	}
+}
+
+func TestGraphicalFunctionRoundtrip(t *testing.T) {
+	tests := []struct {
+		name string
+		gf   GraphicalFunction
+	}{
+		{
+			name: "empty points",
+			gf:   GraphicalFunction{Points: []Point{}},
+		},
+		{
+			name: "single point",
+			gf:   GraphicalFunction{Points: []Point{{X: 1, Y: 2}}},
+		},
+		{
+			name: "multiple points",
+			gf: GraphicalFunction{
+				Points: []Point{
+					{X: 0, Y: 0},
+					{X: 1, Y: 2},
+					{X: 2, Y: 4},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.gf)
+			require.NoError(t, err)
+
+			var gf GraphicalFunction
+			err = json.Unmarshal(data, &gf)
+			require.NoError(t, err)
+
+			require.Len(t, gf.Points, len(tt.gf.Points))
+			for i := range gf.Points {
+				assert.Equal(t, tt.gf.Points[i], gf.Points[i], "Point[%d] mismatch", i)
+			}
+		})
+	}
+}
+
+func TestVariableRoundtrip(t *testing.T) {
+	tests := []struct {
+		name     string
+		variable Variable
+	}{
+		{
+			name: "minimal variable",
+			variable: Variable{
+				Name: "test_var",
+			},
+		},
+		{
+			name: "stock variable with inflows/outflows",
+			variable: Variable{
+				Name:     "inventory",
+				Type:     VariableTypeStock,
+				Units:    "widgets",
+				Inflows:  []string{"production"},
+				Outflows: []string{"sales"},
+			},
+		},
+		{
+			name: "variable with equation",
+			variable: Variable{
+				Name:          "growth_rate",
+				Type:          VariableTypeAux,
+				Equation:      "population * birth_rate",
+				Documentation: "Calculates population growth",
+				Units:         "people/year",
+			},
+		},
+		{
+			name: "variable with graphical function",
+			variable: Variable{
+				Name: "lookup_table",
+				Type: VariableTypeAux,
+				GraphicalFunction: &GraphicalFunction{
+					Points: []Point{
+						{X: 0, Y: 0},
+						{X: 10, Y: 100},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.variable)
+			require.NoError(t, err)
+
+			var v Variable
+			err = json.Unmarshal(data, &v)
+			require.NoError(t, err)
+
+			// Compare fields
+			assert.Equal(t, tt.variable.Name, v.Name)
+			assert.Equal(t, tt.variable.Type, v.Type)
+			assert.Equal(t, tt.variable.Equation, v.Equation)
+			assert.Equal(t, tt.variable.Documentation, v.Documentation)
+			assert.Equal(t, tt.variable.Units, v.Units)
+
+			// Compare slices
+			assert.Equal(t, tt.variable.Inflows, v.Inflows)
+			assert.Equal(t, tt.variable.Outflows, v.Outflows)
+
+			// Compare GraphicalFunction
+			if tt.variable.GraphicalFunction == nil {
+				assert.Nil(t, v.GraphicalFunction)
+			} else {
+				require.NotNil(t, v.GraphicalFunction)
+				assert.Equal(t, tt.variable.GraphicalFunction.Points, v.GraphicalFunction.Points)
+			}
+		})
+	}
+}
+
+func TestRelationshipRoundtrip(t *testing.T) {
+	tests := []struct {
+		name         string
+		relationship Relationship
+	}{
+		{
+			name: "minimal relationship",
+			relationship: Relationship{
+				From:     "cause",
+				To:       "effect",
+				Polarity: "+",
+			},
+		},
+		{
+			name: "relationship with reasoning",
+			relationship: Relationship{
+				From:              "temperature",
+				To:                "ice_cream_sales",
+				Polarity:          "+",
+				Reasoning:         "Higher temperatures increase ice cream demand",
+				PolarityReasoning: "As temperature goes up, sales go up",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.relationship)
+			require.NoError(t, err)
+
+			var r Relationship
+			err = json.Unmarshal(data, &r)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.relationship, r)
+		})
+	}
+}
+
+func TestRelationshipKey(t *testing.T) {
+	tests := []struct {
+		relationship Relationship
+		expectedKey  string
+	}{
+		{
+			relationship: Relationship{From: "A", To: "B", Polarity: "+"},
+			expectedKey:  `"A"->"B"`,
+		},
+		{
+			relationship: Relationship{From: "A", To: "B", Polarity: "-"},
+			expectedKey:  `"A"->"B"`, // polarity is ignored in key
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expectedKey, func(t *testing.T) {
+			assert.Equal(t, tt.expectedKey, tt.relationship.Key())
+		})
+	}
+}
+
+func TestSpecsRoundtrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		specs Specs
+	}{
+		{
+			name: "minimal specs",
+			specs: Specs{
+				StartTime: 0,
+				StopTime:  100,
+			},
+		},
+		{
+			name: "full specs",
+			specs: Specs{
+				StartTime: 0,
+				StopTime:  365,
+				DT:        0.25,
+				SaveStep:  1,
+				TimeUnits: "days",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.specs)
+			require.NoError(t, err)
+
+			var s Specs
+			err = json.Unmarshal(data, &s)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.specs, s)
+		})
+	}
+}
+
+func TestModelRoundtrip(t *testing.T) {
+	tests := []struct {
+		name       string
+		model      Model
+		serialized string
+	}{
+		{
+			name:       "empty model",
+			model:      Model{},
+			serialized: `{}`,
+		},
+		{
+			name: "complete model",
+			model: Model{
+				Variables: []Variable{
+					{
+						Name:     "population",
+						Type:     VariableTypeStock,
+						Units:    "people",
+						Inflows:  []string{"births"},
+						Outflows: []string{"deaths"},
+					},
+					{
+						Name:          "birth_rate",
+						Type:          VariableTypeAux,
+						Documentation: "Birth rate of the population",
+						Equation:      "0.02",
+						Units:         "1/year",
+					},
+					{
+						Name:     "births",
+						Type:     VariableTypeFlow,
+						Equation: "population * birth_rate",
+						Units:    "people/year",
+					},
+					{
+						Name:          "some_gf",
+						Type:          VariableTypeAux,
+						Documentation: "for testing",
+						Units:         "dmnl",
+						GraphicalFunction: &GraphicalFunction{
+							Points: []Point{
+								{X: 0, Y: 0},
+								{X: 10, Y: 100},
+							},
+						},
+					},
+				},
+				Relationships: []Relationship{
+					{
+						From:              "population",
+						To:                "births",
+						Polarity:          "+",
+						PolarityReasoning: "Births come from individuals in the population",
+					},
+					{
+						From:      "birth_rate",
+						To:        "births",
+						Polarity:  "+",
+						Reasoning: "need a rate for births",
+					},
+				},
+				Specs: Specs{
+					StartTime: 0,
+					StopTime:  100,
+					DT:        0.25,
+					TimeUnits: "years",
+				},
+			},
+			serialized: `{
+  "variables": [
+    {
+      "name": "population",
+      "type": "stock",
+      "units": "people",
+      "inflows": [
+        "births"
+      ],
+      "outflows": [
+        "deaths"
+      ]
+    },
+    {
+      "name": "birth_rate",
+      "type": "variable",
+      "equation": "0.02",
+      "documentation": "Birth rate of the population",
+      "units": "1/year"
+    },
+    {
+      "name": "births",
+      "type": "flow",
+      "equation": "population * birth_rate",
+      "units": "people/year"
+    },
+    {
+      "name": "some_gf",
+      "type": "variable",
+      "documentation": "for testing",
+      "units": "dmnl",
+      "graphicalFunction": {
+        "points": [
+          {
+            "x": 0,
+            "y": 0
+          },
+          {
+            "x": 10,
+            "y": 100
+          }
+        ]
+      }
+    }
+  ],
+  "relationships": [
+    {
+      "from": "population",
+      "to": "births",
+      "polarity": "+",
+      "polarityReasoning": "Births come from individuals in the population"
+    },
+    {
+      "from": "birth_rate",
+      "to": "births",
+      "polarity": "+",
+      "reasoning": "need a rate for births"
+    }
+  ],
+  "specs": {
+    "startTime": 0,
+    "stopTime": 100,
+    "dt": 0.25,
+    "timeUnits": "years"
+  }
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.MarshalIndent(tt.model, "", "  ")
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.serialized, string(data))
+
+			var m Model
+			err = json.Unmarshal(data, &m)
+			require.NoError(t, err)
+
+			assert.Len(t, m.Variables, len(tt.model.Variables))
+			assert.Len(t, m.Relationships, len(tt.model.Relationships))
+			assert.Equal(t, tt.model.Specs, m.Specs)
+		})
+	}
+}

--- a/routes/v1/engineGenerate.js
+++ b/routes/v1/engineGenerate.js
@@ -5,7 +5,8 @@ const router = express.Router()
 
 router.post("/:engine/generate", async (req, res) => {
     const authenticationKey = process.env.AUTHENTICATION_KEY;
-    const capabilities = new ModelCapabilities(req.body.underlyingModel);
+    const underlyingModel = req.body.underlyingModel || LLMWrapper.DEFAULT_MODEL;
+    const capabilities = new ModelCapabilities(underlyingModel);
 
     let hasApiKey = false;
     if (req.body.openAIKey && capabilities.kind === ModelType.OPEN_AI) {


### PR DESCRIPTION
r? @wasbridge 

This moves the SD-JSON types + schema to their own package, and tests roundtripping all the types.  With this we no longer need the fix you added JavaScript-side engine.js