### PR TITLE
causal-chains: support for Gemini models

### DIFF
--- a/engines/causal-chains/engine.js
+++ b/engines/causal-chains/engine.js
@@ -34,8 +34,8 @@ class Engine {
 
     additionalParameters() {
         const models = LLMWrapper.MODELS.filter(item => {
-            // true if the value starts with "gpt" or "o[0-9]"
-            return /^(gpt|o\d)/.test(item.value);
+            // true if the value starts with "gpt", "o[0-9]", or contains "gemini"
+            return /^(gpt|o\d)/.test(item.value) || item.value.includes('gemini');
         });
 
         return [
@@ -45,8 +45,17 @@ class Engine {
                 required: false,
                 uiElement: "password",
                 saveForUser: "global",
-                label: "API Key",
-                description: "Leave blank for the default, or your Open AI key, e.g. sk-proj-XXXXX",
+                label: "OpenAI API Key",
+                description: "Leave blank for the default, or your OpenAI API key, e.g. sk-proj-XXXXX",
+            },
+            {
+                name: "googleKey",
+                type: "string",
+                required: false,
+                uiElement: "password",
+                saveForUser: "global",
+                label: "Google API Key",
+                description: "Leave blank for the default, or your Google API key (required for Gemini models)",
             },
             {
                 name: "underlyingModel",

--- a/engines/causal-chains/main_test.go
+++ b/engines/causal-chains/main_test.go
@@ -34,3 +34,33 @@ func TestIsOpenAIModel(t *testing.T) {
 		})
 	}
 }
+
+func TestIsGeminiModel(t *testing.T) {
+	for _, name := range []string{
+		"gemini-2.5-flash",
+		"gemini-2.5-flash-lite-preview-06-17",
+		"gemini-2.5-pro",
+		"gemini-2.0-flash",
+		"gemini-2.0-flash-lite",
+		"gemini-1.5-flash",
+		"GEMINI-1.5-PRO",
+		"Gemini-Pro",
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.True(t, isGeminiModel(name))
+		})
+	}
+
+	for _, name := range []string{
+		"gpt-4o",
+		"llama4:scout",
+		"qwen3:32b",
+		"gemma3:12b",
+		"phi4",
+		"o3-mini",
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.False(t, isGeminiModel(name))
+		})
+	}
+}

--- a/go/llm/openai/client.go
+++ b/go/llm/openai/client.go
@@ -20,6 +20,7 @@ import (
 const (
 	OpenAIURL = "https://api.openai.com/v1"
 	OllamaURL = "http://localhost:11434/v1"
+	GeminiURL = "https://generativelanguage.googleapis.com/v1beta/openai"
 )
 
 type client struct {


### PR DESCRIPTION
I haven't run it myself because I haven't gone through the process of getting an API key, credits, etc but looks good to me!

claude prompt:

> `engines/causal-chains` currently supports OpenAI models as well as locally-hosted ollama ones.  Google's AI stuff uses the same API. Please enable the Go packages to talk to Google Gemini models (I believe the relevant URLs are somewhere in the JavaScript code) in a similar manner that it supports ollama models.  Please write a high quality, general purpose solution. Implement a solution that works correctly for all valid inputs, not just the test cases. Do not hard-code values or create solutions that only work for specific test inputs. Instead, implement the actual logic that solves the problem generally.
>
> Focus on understanding the problem requirements and implementing the correct algorithm. Tests are there to verify correctness, not to define the solution. Provide a principled implementation that follows best practices and software design principles.
>
> If the task is unreasonable or infeasible, or if any of the tests are incorrect, please tell me. The solution should be robust, maintainable, and extendable.
