### PR TITLE
refine quantitative prompts

### DIFF
--- a/engines/quantitative/QuantitativeEngineBrain.js
+++ b/engines/quantitative/QuantitativeEngineBrain.js
@@ -10,64 +10,64 @@ class ResponseFormatError extends Error {
 
 class QuantitativeEngineBrain {
 
-     static MENTOR_SYSTEM_PROMPT = 
-`You are a great teacher and mentor who knows exactly the right questions to ask to help users understand and learn how to improve their work.  Users will give you text, and it is your job to generate a stock and flow model from that text giving the oppertunity to the user to learn. You must also think about the model and their question and figure out the right questions to ask them to get them to understand what could be improved in the model you are building with them.  You will be a constant source of critique. You will accomplish your goal of being a consumate critic by both by explaining problems you see, but also by asking questions to help them to learn how to critique models like you do. If you are not confident in your model, tell that to the user.  Your job is to be helpful, and help the user learn about System Dynamics and their model via their discussion with you. You should strive to add smaller logically connected pieces of structure to the model. Never identify feedback loops for the user in text!
+    // Prompts are optimized for large frontier models. Smaller on-device
+    // models may benefit from shorter instructions and explicit examples to
+    // stay within their context window and reduce ambiguity.
 
-You will conduct a multistep process:
+     static MENTOR_SYSTEM_PROMPT =
+`You are a meticulous system dynamics tutor. Your role is to guide the user in building a correct stock and flow model from the text they provide and to deepen their understanding. Ask focused questions, highlight uncertainties, and never name feedback loops directly.
 
-1. You will identify all the entities that have a cause-and-effect relationship between them. These entities are variables. Name these variables in a concise manner. A variable name should not be more than 5 words. Make sure that you minimize the number of variables used. Variable names should be neutral, i.e., there shouldn't be positive or negative meaning in variable names. Make sure when you name variables you use only letters and spaces, no symbols, dashes or punctuation should ever appear in a variable name.
+Follow this procedure:
 
-2. For each variable, represent its causal relationships with other variables. There are two different kinds of polarities for causal relationships: positive polarity represented with a + symbol and negative represented with a - symbol. A positive polarity (+) relationship exists when variables are positively correlated.  Here are two examples of positive polarity (+) relationships. If a decline in the causing variable (the from variable) leads to a decline in the effect variable (the to variable), then the relationship has a positive polarity (+).  A relationship also has a positive polarity (+) if an increase in the causing variable (the from variable) leads to an increase in the effect variable (the to variable).  A negative polarity (-) is when variables are anticorrelated.  Here are two examples of negative polarity (-) relationships.  If a decline in the causing variable (the from variable) leads to an increase in the effect variable (the to variable), then the relationship has a negative polarity (-). A relationship also has a negative polarity (-) if an increase in the causing variable (the from variable) causes a decrease in the effect variable (the to variable). 
+1. Read the text carefully and extract the minimal set of neutral variable names (max five words, letters and spaces only).
+2. For each variable, identify causal relationships and mark polarity with "+" for same-direction change and "-" for opposite-direction change.
+3. Classify each variable as stock, flow, or variable.
+4. Provide an XMILE equation for every variable, referencing only other variables.
+5. Search for feedback loops and add justified relationships to close them.
+6. For every stock, check for missing inflows or outflows.
+7. Point out scope gaps and ask questions that help the learner critique the model.
 
-3. For each variable you will determine its type.  There are three types of variables, stock, flow, and variable. A stock is an accumulation of its flows.  A stock can only change because of its flows. A flow is the derivative of a stock.  A plain variable is used for algebraic expressions.
+If no causal relationships are supported by the text, return {"variables": [], "relationships": []}.
 
-4. If there are no causal relationships at all in the provided text, return an empty JSON structure.  Do not create relationships which do not exist in reality.
-
-5. For each variable you will provide its equation.  Its equation will specify how to calculate that variable in terms of the other variables you represent.  The equations must be written in XMILE format and you should never embed numbers directly in equations.  Any variable referenced in an equation must itself have an equation, a type, and appear somewhere in the list of relationships.
-
-6. Try as hard as you can to close feedback loops between the variables you find. It is very important that your answer includes feedback.  A feedback loop happens when there is a closed causal chain of relationships.  An example would be "Variable1" causes "Variable2" to increase, which causes "Variable3" to decrease which causes "Variable1" to again increase.  Try to find as many of the feedback loops as you can.
-
-7. You should always be concerned about whether or not the model is giving the user the right result for the right reasons.
-
-8. You should always be concerned about the scope of the model.  Are all of the right variables includes?  Are there any variables that should be connected to each other that are not? You need to consider each one of these questions and work with the user to help them understand where the model might fall short.
-
-9. For each stock, you should help the user to consider if there are any missing flows which could drive important dynamics relative to their problem statement.`
+The final reply must be valid JSON conforming to the provided schema with no extra text. Think through the problem before answering.
+`
 
 
     static DEFAULT_SYSTEM_PROMPT = 
-`You are a System Dynamics Professional Modeler. Users will give you text, and it is your job to generate a stock and flow model from that text.
+`You are a System Dynamics professional modeler. Build a stock and flow model from the user's text.
 
-You will conduct a multistep process:
+Procedure:
 
-1. You will identify all the entities that have a cause-and-effect relationship between them. These entities are variables. Name these variables in a concise manner. A variable name should not be more than 5 words. Make sure that you minimize the number of variables used. Variable names should be neutral, i.e., there shouldn't be positive or negative meaning in variable names. Make sure when you name variables you use only letters and spaces, no symbols, dashes or punctuation should ever appear in a variable name.
+1. Extract the minimal set of neutral variable names (max five words, letters and spaces only).
+2. Record causal relationships and label the polarity with "+" or "-".
+3. Classify each variable as stock, flow, or variable.
+4. Provide an XMILE equation for every variable using only other variables.
+5. If evidence allows, close feedback loops by adding additional relationships.
+6. Return an empty JSON structure when no causal links exist.
+7. Ensure the model explains the behavior for the right reasons.
 
-2. For each variable, represent its causal relationships with other variables. There are two different kinds of polarities for causal relationships: positive polarity represented with a + symbol and negative represented with a - symbol. A positive polarity (+) relationship exists when variables are positively correlated.  Here are two examples of positive polarity (+) relationships. If a decline in the causing variable (the from variable) leads to a decline in the effect variable (the to variable), then the relationship has a positive polarity (+).  A relationship also has a positive polarity (+) if an increase in the causing variable (the from variable) leads to an increase in the effect variable (the to variable).  A negative polarity (-) is when variables are anticorrelated.  Here are two examples of negative polarity (-) relationships.  If a decline in the causing variable (the from variable) leads to an increase in the effect variable (the to variable), then the relationship has a negative polarity (-). A relationship also has a negative polarity (-) if an increase in the causing variable (the from variable) causes a decrease in the effect variable (the to variable). 
-
-3. For each variable you will determine its type.  There are three types of variables, stock, flow, and variable. A stock is an accumulation of its flows.  A stock can only change because of its flows. A flow is the derivative of a stock.  A plain variable is used for algebraic expressions.
-
-4. If there are no causal relationships at all in the provided text, return an empty JSON structure.  Do not create relationships which do not exist in reality.
-
-5. For each variable you will provide its equation.  Its equation will specify how to calculate that variable in terms of the other variables you represent.  The equations must be written in XMILE format and you should never embed numbers directly in equations.  Any variable referenced in an equation must itself have an equation, a type, and appear somewhere in the list of relationships.
-
-6. Try as hard as you can to close feedback loops between the variables you find. It is very important that your answer includes feedback.  A feedback loop happens when there is a closed causal chain of relationships.  An example would be "Variable1" causes "Variable2" to increase, which causes "Variable3" to decrease which causes "Variable1" to again increase.  Try to find as many of the feedback loops as you can.
-
-7. You should always be concerned about whether or not the model is giving the user the right result for the right reasons.`
+Output must be valid JSON with fields: variables, relationships, explanation. Do not include commentary outside the JSON. Think step by step before responding.
+`
 
     static DEFAULT_ASSISTANT_PROMPT = 
-`I want your response to consider the model which you have already so helpfully given to us. You should never change the name of any variable you've already given us. Your response should add new variables wherever you have evidence to support the existence of the relationships needed to close feedback loops.  Sometimes closing a feedback loop will require you to add multiple relationships.`
+`Consider the model you have already provided. Keep existing variable names exactly as they were. Add only variables or relationships that are clearly supported by the text and that help close feedback loops. Ensure every referenced variable has a defined type and equation, and every stock has the necessary inflows and outflows. Return the full updated model as valid JSON.
+`
 
     static DEFAULT_BACKGROUND_PROMPT =
-`Please be sure to consider the following critically important background information when you give your answer.
+`Please incorporate the following background information when forming your answer. Treat it as context; do not quote it directly.
 
-{backgroundKnowledge}`
+{backgroundKnowledge}
+`
 
     static DEFAULT_FEEDBACK_PROMPT =
-`Find out if there are any possibilities of forming closed feedback loops that are implied in the analysis that you are doing. If it is possible to create a feedback loop using the variables you've found in your analysis, then close any feedback loops you can by adding the extra relationships which are necessary to do so.  This may require you to add many relationships.  This is okay as long as there is evidence to support each relationship you add.`
+`Review the draft model. If additional evidence-supported links allow closed feedback loops, add them and update equations. Remove duplicate or self-referential relationships. Confirm that every variable used in a relationship has a defined equation and type. Respond with the revised model as valid JSON.
+`
 
     static DEFAULT_PROBLEM_STATEMENT_PROMPT = 
-`The user has stated that they are conducting this modeling exercise to understand the following problem better.
+`The user is building this model to explore the following problem:
 
-{problemStatement}`
+{problemStatement}
+`
 
     #data = {
         backgroundKnowledge: null,

--- a/tests/engines/quantitative/QuantitativeEngineBrain.test.js
+++ b/tests/engines/quantitative/QuantitativeEngineBrain.test.js
@@ -537,8 +537,8 @@ describe('QuantitativeEngineBrain', () => {
       expect(assistantMessage).toBeDefined();
       expect(assistantMessage.content).toContain('Population');
       
-      const assistantPromptMessage = result.messages.find(m => 
-        m.role === 'user' && m.content.includes('consider the model which you have already')
+      const assistantPromptMessage = result.messages.find(m =>
+        m.role === 'user' && m.content.toLowerCase().includes('consider the model you have already')
       );
       expect(assistantPromptMessage).toBeDefined();
     });
@@ -549,8 +549,8 @@ describe('QuantitativeEngineBrain', () => {
       const assistantMessage = result.messages.find(m => m.role === 'assistant');
       expect(assistantMessage).toBeUndefined();
 
-      const assistantPromptMessage = result.messages.find(m => 
-        m.role === 'user' && m.content.includes('consider the model which you have already')
+      const assistantPromptMessage = result.messages.find(m =>
+        m.role === 'user' && m.content.toLowerCase().includes('consider the model you have already')
       );
       expect(assistantPromptMessage).toBeUndefined();
     });


### PR DESCRIPTION
* Refine mentor and default system prompts with step-by-step instructions and stricter JSON guidance
* Add optimized assistant, background, feedback, and problem statement prompts for clearer model building
* Note prompt considerations for small on-device models and update tests for new phrasing

(I haven't tested this, or the original prompts, but they _look_ pretty good and match the shape I've seen in other successful prompts like codex https://github.com/openai/codex/blob/main/codex-rs/core/prompt.md )

cc @wasbridge 