### PR TITLE
fix oscillation detection for non-sinusoidal waveforms

### DIFF
--- a/evals/categories/behavioralPattern.js
+++ b/evals/categories/behavioralPattern.js
@@ -61,6 +61,81 @@ const generateBasicBehaviorModeTest = function(name, patternDescription, expecte
 
 
 /**
+ * Fallback oscillation detector using zero-crossing analysis.
+ *
+ * The curve-fitting classifier (third-party) can misclassify non-sinusoidal
+ * oscillations (e.g. relaxation oscillations from a Van der Pol oscillator)
+ * because its sine model is a poor fit for the waveform shape. This heuristic
+ * catches those cases by looking at sign changes after detrending.
+ *
+ * @param {Array<number>} timeSeries - The time series values
+ * @returns {{ isOscillating: boolean, zeroCrossings: number, amplitude: number, sustainedInBothHalves: boolean }}
+ */
+export function detectOscillationFallback(timeSeries) {
+    if (!timeSeries || timeSeries.length < 3) {
+        return { isOscillating: false, zeroCrossings: 0, amplitude: 0, sustainedInBothHalves: false };
+    }
+
+    const n = timeSeries.length;
+    const mean = timeSeries.reduce((a, b) => a + b, 0) / n;
+
+    // Detrend by subtracting the mean so we can count zero-crossings
+    const detrended = timeSeries.map(v => v - mean);
+
+    // Count zero-crossings (sign changes) and record their positions
+    const crossingIndices = [];
+    for (let i = 1; i < n; i++) {
+        if ((detrended[i - 1] >= 0 && detrended[i] < 0) ||
+            (detrended[i - 1] < 0 && detrended[i] >= 0)) {
+            crossingIndices.push(i);
+        }
+    }
+    const zeroCrossings = crossingIndices.length;
+
+    const dataMax = timeSeries.reduce((max, v) => v > max ? v : max, -Infinity);
+    const dataMin = timeSeries.reduce((min, v) => v < min ? v : min, Infinity);
+    const amplitude = dataMax - dataMin;
+    const absMean = Math.abs(mean);
+
+    // Check that oscillation is present in both halves of the series
+    const mid = Math.floor(n / 2);
+    const firstHalfCrossings = crossingIndices.filter(idx => idx < mid).length;
+    const secondHalfCrossings = crossingIndices.filter(idx => idx >= mid).length;
+    const sustainedInBothHalves = firstHalfCrossings >= 1 && secondHalfCrossings >= 1;
+
+    const hasEnoughCrossings = zeroCrossings >= 4;
+
+    // Amplitude must be above an absolute floor (to reject constant series)
+    // AND, when the mean is far from zero, must also be significant relative
+    // to the mean (to reject tiny ripples on a large offset).
+    const AMPLITUDE_FLOOR = 1e-6;
+    const hasSignificantAmplitude =
+        amplitude > AMPLITUDE_FLOOR &&
+        (absMean < AMPLITUDE_FLOOR || amplitude > 0.1 * absMean);
+
+    // Periodicity check: true oscillation has roughly regular intervals
+    // between zero crossings. Noise or detrended trends have irregular ones.
+    // Require the coefficient of variation (std/mean) to be below a threshold.
+    let isPeriodic = false;
+    if (crossingIndices.length >= 4) {
+        const intervals = [];
+        for (let i = 1; i < crossingIndices.length; i++) {
+            intervals.push(crossingIndices[i] - crossingIndices[i - 1]);
+        }
+        const intervalMean = intervals.reduce((a, b) => a + b, 0) / intervals.length;
+        const intervalVariance = intervals.reduce((sum, v) => sum + (v - intervalMean) ** 2, 0) / intervals.length;
+        const intervalStd = Math.sqrt(intervalVariance);
+        const cv = intervalStd / intervalMean;
+        isPeriodic = cv < 0.5;
+    }
+
+    const isOscillating = hasEnoughCrossings && hasSignificantAmplitude && sustainedInBothHalves && isPeriodic;
+
+    return { isOscillating, zeroCrossings, amplitude, sustainedInBothHalves };
+}
+
+
+/**
  * Evaluates whether the generated model produces the expected behavioral pattern
  * @param {Object} generatedResponse The response from the engine containing the model
  * @param {Object} requirements The expected behavioral pattern
@@ -148,6 +223,23 @@ export const evaluate = async function(generatedResponse, requirements) {
                 details: `Failed to classify behavior: ${error.message}`
             });
             return validateEvaluationResult(fails);
+        }
+
+        // Fallback: the curve-fitting classifier can miss non-sinusoidal
+        // oscillations (e.g. relaxation oscillations).  If the expected pattern
+        // is in the oscillation family and the classifier disagrees, run a
+        // simple zero-crossing heuristic before reporting a failure.
+        const oscillationFamilyPatterns = new Set(['oscillating', 'dampening']);
+        if (!patternCheck.matches && oscillationFamilyPatterns.has(expectedPattern)) {
+            const fallback = detectOscillationFallback(outputTimeSeries);
+            if (fallback.isOscillating) {
+                patternCheck = {
+                    ...patternCheck,
+                    matches: true,
+                    detected: expectedPattern,
+                    confidence: 0.75,
+                };
+            }
         }
 
         if (!patternCheck.matches) {

--- a/tests/evals/categories/behavioralPatternFallback.test.js
+++ b/tests/evals/categories/behavioralPatternFallback.test.js
@@ -1,0 +1,173 @@
+import { describe, test, expect } from '@jest/globals';
+import { detectOscillationFallback } from '../../../evals/categories/behavioralPattern.js';
+
+/**
+ * Generate Van der Pol oscillator output using Euler integration.
+ * position' = velocity
+ * velocity' = mu * (1 - position^2) * velocity - position
+ */
+function generateVanDerPol(mu = 1, posInit = 0.1, velInit = 0, dt = 0.03125, stopTime = 100, saveStep = 0.25) {
+    let pos = posInit;
+    let vel = velInit;
+    const saveEvery = Math.round(saveStep / dt);
+    const totalSteps = Math.round(stopTime / dt);
+
+    const results = [pos];
+    for (let i = 1; i <= totalSteps; i++) {
+        const dPos = vel;
+        const dVel = mu * (1 - pos * pos) * vel - pos;
+        pos += dPos * dt;
+        vel += dVel * dt;
+        if (i % saveEvery === 0) {
+            results.push(pos);
+        }
+    }
+    return results;
+}
+
+describe('detectOscillationFallback', () => {
+
+    test('should detect a pure sinusoidal oscillation', () => {
+        const data = Array.from({ length: 400 }, (_, i) =>
+            2.0 * Math.sin(2 * Math.PI * i / 50)
+        );
+        const result = detectOscillationFallback(data);
+        expect(result.isOscillating).toBe(true);
+        expect(result.zeroCrossings).toBeGreaterThanOrEqual(4);
+    });
+
+    test('should detect Van der Pol relaxation oscillation', () => {
+        const data = generateVanDerPol();
+        expect(data.length).toBe(401);
+
+        const result = detectOscillationFallback(data);
+        expect(result.isOscillating).toBe(true);
+        expect(result.zeroCrossings).toBeGreaterThanOrEqual(4);
+        expect(result.sustainedInBothHalves).toBe(true);
+    });
+
+    test('should NOT detect a flat/constant time series as oscillating', () => {
+        const data = Array.from({ length: 400 }, () => 5.0);
+        const result = detectOscillationFallback(data);
+        expect(result.isOscillating).toBe(false);
+    });
+
+    test('should NOT detect exponential growth as oscillating', () => {
+        const data = Array.from({ length: 400 }, (_, i) =>
+            Math.exp(0.01 * i)
+        );
+        const result = detectOscillationFallback(data);
+        expect(result.isOscillating).toBe(false);
+    });
+
+    test('should NOT detect linear growth as oscillating', () => {
+        const data = Array.from({ length: 400 }, (_, i) => 3 * i + 10);
+        const result = detectOscillationFallback(data);
+        expect(result.isOscillating).toBe(false);
+    });
+
+    test('should NOT detect exponential decay as oscillating', () => {
+        const data = Array.from({ length: 400 }, (_, i) =>
+            100 * Math.exp(-0.02 * i)
+        );
+        const result = detectOscillationFallback(data);
+        expect(result.isOscillating).toBe(false);
+    });
+
+    test('should NOT detect s-curve/logistic growth as oscillating', () => {
+        const data = Array.from({ length: 400 }, (_, i) =>
+            100 / (1 + Math.exp(-0.05 * (i - 200)))
+        );
+        const result = detectOscillationFallback(data);
+        expect(result.isOscillating).toBe(false);
+    });
+
+    test('should detect dampened oscillation', () => {
+        const data = Array.from({ length: 400 }, (_, i) =>
+            5.0 * Math.exp(-0.005 * i) * Math.sin(2 * Math.PI * i / 40)
+        );
+        const result = detectOscillationFallback(data);
+        expect(result.isOscillating).toBe(true);
+        expect(result.sustainedInBothHalves).toBe(true);
+    });
+
+    test('should NOT detect a tiny oscillation with negligible amplitude', () => {
+        // Oscillation with amplitude 0.001 around mean of 100 -- amplitude is
+        // less than 10% of |mean|
+        const data = Array.from({ length: 400 }, (_, i) =>
+            100 + 0.001 * Math.sin(2 * Math.PI * i / 50)
+        );
+        const result = detectOscillationFallback(data);
+        expect(result.isOscillating).toBe(false);
+    });
+
+    test('should handle oscillation around a non-zero mean by detrending', () => {
+        // Oscillation centered at 50 with amplitude 10
+        const data = Array.from({ length: 400 }, (_, i) =>
+            50 + 10 * Math.sin(2 * Math.PI * i / 50)
+        );
+        const result = detectOscillationFallback(data);
+        expect(result.isOscillating).toBe(true);
+    });
+
+    test('should handle short time series with few points', () => {
+        const data = [1, -1, 1, -1, 1];
+        const result = detectOscillationFallback(data);
+        // 4 zero crossings, has amplitude, but series is very short
+        expect(result.isOscillating).toBe(true);
+    });
+
+    test('should NOT detect a step function as oscillating', () => {
+        const data = Array.from({ length: 400 }, (_, i) =>
+            i < 200 ? 0 : 10
+        );
+        const result = detectOscillationFallback(data);
+        expect(result.isOscillating).toBe(false);
+    });
+
+    test('should NOT detect noise around zero with too few crossings as oscillating', () => {
+        // Just 2 sign changes -- not enough
+        const data = Array.from({ length: 400 }, (_, i) => {
+            if (i < 100) return 1;
+            if (i < 200) return -1;
+            if (i < 300) return 0.5;
+            return 0.5;
+        });
+        const result = detectOscillationFallback(data);
+        expect(result.zeroCrossings).toBeLessThan(4);
+        expect(result.isOscillating).toBe(false);
+    });
+
+    test('should NOT detect slow exponential growth with noise as oscillating', () => {
+        // A slow exponential with additive noise can produce zero crossings
+        // after detrending, but those crossings are irregularly spaced.
+        const seed = 12345;
+        let rng = seed;
+        function pseudoRandom() {
+            rng = (rng * 16807 + 0) % 2147483647;
+            return (rng / 2147483647) - 0.5;
+        }
+        const data = Array.from({ length: 400 }, (_, i) =>
+            Math.exp(0.005 * i) + 0.5 * pseudoRandom()
+        );
+        const result = detectOscillationFallback(data);
+        expect(result.isOscillating).toBe(false);
+    });
+
+    test('should NOT detect noisy non-oscillating data with irregular zero crossings', () => {
+        // Random-walk-like data centered near zero produces many zero
+        // crossings, but they are irregularly spaced.
+        const seed = 67890;
+        let rng = seed;
+        function pseudoRandom() {
+            rng = (rng * 16807 + 0) % 2147483647;
+            return (rng / 2147483647) - 0.5;
+        }
+        const data = [0];
+        for (let i = 1; i < 400; i++) {
+            data.push(data[i - 1] + pseudoRandom());
+        }
+        const result = detectOscillationFallback(data);
+        expect(result.isOscillating).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- The third-party curve-fitting classifier misclassifies relaxation oscillations (e.g. Van der Pol) as stable because its sine model can't fit non-sinusoidal waveforms
- Add a zero-crossing fallback heuristic that activates only when the expected pattern is oscillation-family and the classifier disagrees
- Includes comprehensive tests covering sinusoidal, Van der Pol, damped, and various non-oscillating patterns

## Test plan
- [ ] Unit tests pass: `npx jest tests/evals/categories/behavioralPatternFallback.test.js`
- [ ] Existing behavioral pattern tests still pass
- [ ] Van der Pol oscillator correctly detected as oscillating
- [ ] Non-oscillating patterns (flat, exponential, logistic, step) correctly rejected